### PR TITLE
Correct prefixes and make links instead of moving files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,22 @@
 # All rights reserved.
 #
 
-
 .PHONY: all
 all:
 	( cd makefiles && make -f Makefile.dl )
 	( cd makefiles && make -f Makefile.binutils )
 	( cd makefiles && make -f Makefile.cmake )
 	( cd makefiles && make -f Makefile.llvm )
+
+
+.PHONY: install
+install:
+	( cd makefiles && make -f Makefile.llvm install )
+
+
+.PHONY: uninstall
+uninstall:
+	( cd makefiles && make -f Makefile.llvm uninstall )
 
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ download:
 help:
 	@echo "Makefile to build llvm as cross compiler for ARM Cortex-M"
 	@echo " "
-	@echo "make [INST_PREFIX=/path]  - build cross compiler"
-	@echo "make clean                - clean object files"
-	@echo "make download             - download llvm/binutils source if required"
+	@echo "make [INST_PREFIX=/path]             - build cross compiler"
+	@echo "make [INST_PREFIX=/path] (un)install - (un)install cross compiler"
+	@echo "make clean                           - clean object files"
+	@echo "make download                        - download llvm/binutils source if required"

--- a/makefiles/Makefile.binutils
+++ b/makefiles/Makefile.binutils
@@ -36,7 +36,7 @@ build_binutils: $(BUILD_DIR)
 	( cd $(BUILD_DIR)/$(BINUTIL_VERSION)  &&  CFLAGS="-w " \
 	./configure \
 		--target=$(TARGET) \
-		--prefix=$(DEST_PREFIX) \
+		--prefix=$(PREFIX) \
 		--disable-shared \
 		--disable-werror \
 		--disable-nls \

--- a/makefiles/Makefile.binutils
+++ b/makefiles/Makefile.binutils
@@ -36,16 +36,14 @@ build_binutils: $(BUILD_DIR)
 	( cd $(BUILD_DIR)/$(BINUTIL_VERSION)  &&  CFLAGS="-w " \
 	./configure \
 		--target=$(TARGET) \
-		--prefix=$(PREFIX) \
+		--prefix=$(DEST_PREFIX) \
 		--disable-shared \
 		--disable-werror \
 		--disable-nls \
 		--disable-threads \
 		--enable-interwork \
 		--enable-multilib \
-		--enable-lto \
-		--with-local-prefix=$(SYSROOT_PREFIX)/$(TARGET) \
-		--with-sysroot=$(SYSROOT_PREFIX)/$(TARGET)  )
+		--enable-lto )
 	( cd $(BUILD_DIR)/$(BINUTIL_VERSION)  && $(MAKE) $(MJOBS) )
 	( cd $(BUILD_DIR)/$(BINUTIL_VERSION)  && $(MAKE) install )
 

--- a/makefiles/Makefile.llvm
+++ b/makefiles/Makefile.llvm
@@ -35,12 +35,11 @@ COMPILER_RT_FILES_ARM=arm/aeabi_memcpy.S \
 	
 .PHONY: build
 build:
-	$(MAKE) -f $(MAKEFILENAME) $(DEST_PREFIX)/bin/$(TARGET)-clang
+	$(MAKE) -f $(MAKEFILENAME) build_clang
 
 
 .PHONY: clean
 clean:
-	$(RM) -f     $(DEST_PREFIX)/bin/$(TARGET)-clang
 	$(RM) -rf    $(BUILD_DIR)/$(LLVM_VERSION)
 	$(RM) -rf    $(BUILD_DIR)/$(LLVM_VERSION).src
 	$(RM) -rf    $(BUILD_DIR)/$(LLVM_VERSION).build
@@ -48,11 +47,21 @@ clean:
 
 .PHONY: install
 install:
+	( cd $(BUILD_DIR)/$(LLVM_VERSION).build && \
+		$(PATH_EXT) time make install )
+	( cd $(DEST_PREFIX)/bin && ln -s clang $(TARGET)-clang )
+	( cd $(DEST_PREFIX)/bin && ln -s clang++ $(TARGET)-clang++ )
+	$(MKDIR) -p $(DEST_PREFIX)/local/include
+	( cd $(DEST_PREFIX)/lib/clang && ln -s $(LLVM_VERSION_NO) current )
+	$(MAKE) -f $(MAKEFILENAME) compiler_rt
+	$(MAKE) -f $(MAKEFILENAME) pack_clang
 
-
-$(DEST_PREFIX)/bin/$(TARGET)-clang:
-	$(MAKE) -f $(MAKEFILENAME) build_clang
-
+.PHONY: uninstall
+uninstall:
+	( cd $(DEST_PREFIX)/bin && $(RM) -f clang $(TARGET)-clang )
+	( cd $(DEST_PREFIX)/bin && $(RM) -f clang++ $(TARGET)-clang++ )
+	$(RM) -rf $(DEST_PREFIX)/local/include
+	$(RM) -rf $(DEST_PREFIX)/lib/clang
 
 .PHONY: extract_clang
 extract_clang:
@@ -99,14 +108,6 @@ build_clang: $(BUILD_DIR)
 		-DLLVM_PARALLEL_COMPILE_JOBS:STRING=$(NUM_CPUS) )
 	( cd $(BUILD_DIR)/$(LLVM_VERSION).build && \
 		$(PATH_EXT) time make $(MJOBS) )
-	( cd $(BUILD_DIR)/$(LLVM_VERSION).build && \
-		$(PATH_EXT) time make install )
-	( cd $(DEST_PREFIX)/bin && ln -s clang $(TARGET)-clang )
-	( cd $(DEST_PREFIX)/bin && ln -s clang++ $(TARGET)-clang++ )
-	$(MKDIR) -p $(DEST_PREFIX)/local/include
-	( cd $(DEST_PREFIX)/lib/clang && ln -s $(LLVM_VERSION_NO) current )
-	$(MAKE) -f $(MAKEFILENAME) compiler_rt
-	$(MAKE) -f $(MAKEFILENAME) pack_clang
 
 
 .PHONY: pack_clang

--- a/makefiles/Makefile.llvm
+++ b/makefiles/Makefile.llvm
@@ -49,10 +49,10 @@ clean:
 install:
 	( cd $(BUILD_DIR)/$(LLVM_VERSION).build && \
 		$(PATH_EXT) time make install )
-	( cd $(DEST_PREFIX)/bin && ln -s clang $(TARGET)-clang )
-	( cd $(DEST_PREFIX)/bin && ln -s clang++ $(TARGET)-clang++ )
+	( cd $(DEST_PREFIX)/bin && ln -sf clang $(TARGET)-clang )
+	( cd $(DEST_PREFIX)/bin && ln -sf clang++ $(TARGET)-clang++ )
 	$(MKDIR) -p $(DEST_PREFIX)/local/include
-	( cd $(DEST_PREFIX)/lib/clang && ln -s $(LLVM_VERSION_NO) current )
+	( cd $(DEST_PREFIX)/lib/clang && ln -sf $(LLVM_VERSION_NO) current )
 	$(MAKE) -f $(MAKEFILENAME) compiler_rt
 	$(MAKE) -f $(MAKEFILENAME) pack_clang
 

--- a/makefiles/Makefile.llvm
+++ b/makefiles/Makefile.llvm
@@ -35,12 +35,12 @@ COMPILER_RT_FILES_ARM=arm/aeabi_memcpy.S \
 	
 .PHONY: build
 build:
-	$(MAKE) -f $(MAKEFILENAME) $(PREFIX)/bin/$(TARGET)-clang
+	$(MAKE) -f $(MAKEFILENAME) $(DEST_PREFIX)/bin/$(TARGET)-clang
 
 
 .PHONY: clean
 clean:
-	$(RM) -f $(PREFIX)/bin/$(TARGET)-clang
+	$(RM) -f     $(DEST_PREFIX)/bin/$(TARGET)-clang
 	$(RM) -rf    $(BUILD_DIR)/$(LLVM_VERSION)
 	$(RM) -rf    $(BUILD_DIR)/$(LLVM_VERSION).src
 	$(RM) -rf    $(BUILD_DIR)/$(LLVM_VERSION).build
@@ -50,7 +50,7 @@ clean:
 install:
 
 
-$(PREFIX)/bin/$(TARGET)-clang:
+$(DEST_PREFIX)/bin/$(TARGET)-clang:
 	$(MAKE) -f $(MAKEFILENAME) build_clang
 
 
@@ -83,7 +83,7 @@ build_clang: $(BUILD_DIR)
 		$(PATH_EXT) cmake ../$(LLVM_VERSION).src \
 		-G "Unix Makefiles" \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) \
+		-DCMAKE_INSTALL_PREFIX:PATH=$(DEST_PREFIX) \
 		-DCMAKE_CROSSCOMPILING=True \
 		-DLLVM_TARGETS_TO_BUILD=ARM \
 		-DLLVM_DEFAULT_TARGET_TRIPLE=$(TARGET) \
@@ -101,10 +101,10 @@ build_clang: $(BUILD_DIR)
 		$(PATH_EXT) time make $(MJOBS) )
 	( cd $(BUILD_DIR)/$(LLVM_VERSION).build && \
 		$(PATH_EXT) time make install )
-	( cd $(PREFIX)/bin && mv clang $(TARGET)-clang )
-	( cd $(PREFIX)/bin && mv clang++ $(TARGET)-clang++ )
-	$(MKDIR) -p $(PREFIX)/local/include
-	( cd $(PREFIX)/lib/clang && ln -s $(LLVM_VERSION_NO) current )
+	( cd $(DEST_PREFIX)/bin && ln -s clang $(TARGET)-clang )
+	( cd $(DEST_PREFIX)/bin && ln -s clang++ $(TARGET)-clang++ )
+	$(MKDIR) -p $(DEST_PREFIX)/local/include
+	( cd $(DEST_PREFIX)/lib/clang && ln -s $(LLVM_VERSION_NO) current )
 	$(MAKE) -f $(MAKEFILENAME) compiler_rt
 	$(MAKE) -f $(MAKEFILENAME) pack_clang
 


### PR DESCRIPTION
Hello Heiko,
This patch allowed me to build and use clang on Ubuntu 16.04.2 LTS.
Best Regards,
Gautier.